### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         python -m pip install tox
     - name: tox
       run: |
-        tox -e ${{ matrix.tox-job }}q
+        tox -e ${{ matrix.tox-job }}
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
-        python -m pip install pre-commit
     - name: tox
       run: |
         tox -e py
-    - name: pre-commit linters
-      run: |
-        pre-commit install && pre-commit run --all-files
     - name: coverage
       if: ${{ success() }}
       run: bash <(curl -s https://codecov.io/bash)
@@ -46,7 +42,6 @@ jobs:
       matrix:
         python-version: ['3.10']
         tox-job: ["mypy", "docs"]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -57,10 +52,22 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
+    - name: tox
+      run: |
+        tox -e ${{ matrix.tox-job }}q
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
         python -m pip install pre-commit
     - name: pre-commit linters
       run: |
         pre-commit install && pre-commit run --all-files
-    - name: tox
-      run: |
-        tox -e ${{ matrix.tox-job }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: isort
         language_version: python3
     repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
   - hooks:
       - id: flake8
         language_version: python3
@@ -17,10 +17,5 @@ repos:
           - flake8-comprehensions
           - flake8-debugger
           - flake8-string-format
-    repo: https://gitlab.com/pycqa/flake8
+    repo: https://github.com/pycqa/flake8
     rev: 4.0.1
-  - hooks:
-      - id: mypy
-        additional_dependencies: ["types-dataclasses>=0.6.1; python_version < '3.7'"]
-    repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.910"

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,6 @@ commands =
         --doctest-modules \
         {posargs:url_matcher tests}
 
-[testenv:mypy]
-deps =
-    mypy==0.910
-
-commands = mypy --ignore-missing-imports --no-warn-no-return url_matcher tests
-
 [docs]
 changedir = docs
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,12 @@ commands =
         --doctest-modules \
         {posargs:url_matcher tests}
 
+[testenv:mypy]
+deps =
+    mypy==0.910
+
+commands = mypy --ignore-missing-imports --no-warn-no-return url_matcher tests
+
 [docs]
 changedir = docs
 deps =

--- a/url_matcher/patterns.py
+++ b/url_matcher/patterns.py
@@ -216,6 +216,7 @@ class PatternMatcher:
                     warnings.warn(
                         f"Wildcard expansion is only allowed for the values in the query parameter. Pattern: '{self.pattern}'",
                         SyntaxWarning,
+                        stacklevel=3,
                     )
                     pparam = pparam.replace("*", "")
                 if not pparam:


### PR DESCRIPTION
- Run pre-commit in CI only once, in its own, separate job.
- Fix the pre-commit flake8 URL (gitlab → github).
- Upgrade isort, [installation was failing otherwise](https://stackoverflow.com/q/75269700/939364).
- Remove mypy from pre-commit, it already runs in CI and it takes longer than all other hooks combined.
- Fix a flake8-reported issue about a missing stacklevel argument.