### PR TITLE
Document the match, match_all and match_universal methods

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -147,6 +147,8 @@ Fragment patterns
 It works exactly like the path.
 
 
+.. _conflict-resolution:
+
 Rules conflict resolution
 =========================
 
@@ -167,6 +169,10 @@ The full criteria applied to resolve a conflict between rules are:
   2. priority (the highest wins)
   3. specificity (the most specific include patterns for the concerning domain wins)
   4. the rule id (the rule with the highest id wins)
+
+Use :meth:`~url_matcher.URLMatcher.match_all` instead of
+:meth:`~url_matcher.URLMatcher.match` to get every matching rule, in that same
+order, rather than only the winner.
 
 Efficiency
 ==========

--- a/url_matcher/matcher.py
+++ b/url_matcher/matcher.py
@@ -150,9 +150,25 @@ class URLMatcher:
         return self.patterns.get(identifier)
 
     def match(self, url: str, *, include_universal: bool = True) -> Any | None:
+        """Return the identifier of the rule that matches *url*, or ``None`` if
+        no rule matches it.
+
+        When several rules match, the one that wins according to the
+        :ref:`conflict resolution criteria <conflict-resolution>` is returned.
+
+        If *include_universal* is false, rules with a universal include pattern
+        are ignored.
+        """
         return next(self.match_all(url, include_universal=include_universal), None)
 
     def match_all(self, url: str, *, include_universal: bool = True) -> Iterator[Any]:
+        """Yield the identifier of every rule that matches *url*, best match
+        first according to the
+        :ref:`conflict resolution criteria <conflict-resolution>`.
+
+        If *include_universal* is false, rules with a universal include pattern
+        are ignored.
+        """
         domain = get_domain(url)
         matchers: Iterable[PatternsMatcher] = self.matchers_by_domain.get(domain) or []
         if include_universal:
@@ -162,6 +178,10 @@ class URLMatcher:
                 yield matcher.identifier
 
     def match_universal(self) -> Iterator[Any]:
+        """Yield the identifier of every rule with a universal include pattern,
+        best match first according to the
+        :ref:`conflict resolution criteria <conflict-resolution>`.
+        """
         return (m.identifier for m in self.matchers_universal)
 
     def _sort_domain(self, domain: str) -> None:


### PR DESCRIPTION
Fixes https://github.com/zytedata/url-matcher/issues/13.

To do:
- [x] Re-run after merging https://github.com/zytedata/url-matcher/pull/25.